### PR TITLE
Update volume naming for rbd, pv and pvc to NAMESPACE-PVCNAME-ShortUUID

### DIFF
--- a/ceph/rbd/pkg/provision/provision.go
+++ b/ceph/rbd/pkg/provision/provision.go
@@ -123,7 +123,9 @@ func (p *rbdProvisioner) Provision(options controller.VolumeOptions) (*v1.Persis
 		return nil, err
 	}
 	// create random image name
-	image := fmt.Sprintf("kubernetes-dynamic-pvc-%s", uuid.NewUUID())
+	uuid := fmt.Sprintf("%s", uuid.NewUUID())
+	suuid := uuid[:strings.IndexByte(uuid, '-')]
+	image := fmt.Sprintf("%s-%s-%s", options.PVC.Namespace, options.PVC.Name, suuid)
 	rbd, sizeMB, err := p.rbdUtil.CreateImage(image, opts, options)
 	if err != nil {
 		glog.Errorf("rbd: create volume failed, err: %v", err)
@@ -140,7 +142,7 @@ func (p *rbdProvisioner) Provision(options controller.VolumeOptions) (*v1.Persis
 
 	pv := &v1.PersistentVolume{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: options.PVName,
+			Name: image,
 			Annotations: map[string]string{
 				provisionerIDAnn: p.identity,
 			},


### PR DESCRIPTION
This update provides a more human readable naming convention for the RBD volume, PV and PVC.

Inspired from the netapp-trident provisionner volume naming.